### PR TITLE
Enable multi-task support in the application.

### DIFF
--- a/lolibot/services/processor.py
+++ b/lolibot/services/processor.py
@@ -1,4 +1,9 @@
+"""Task processing module."""
+
+import re
 from dataclasses import dataclass
+from typing import List, Set, Optional, Tuple
+
 from lolibot.config import BotConfig
 from lolibot.llm.processor import LLMProcessor
 from lolibot.services.middleware.not_task import NotTaskMiddleWare
@@ -13,19 +18,127 @@ from lolibot.services.middleware import (
 
 @dataclass
 class TaskResponse:
-    task: TaskData
-    processed: bool = False
+    """Response from processing one or more tasks."""
+
+    tasks: List[TaskData]
+    processed: List[bool]
+    messages: List[str]
+
+    def has_any_success(self) -> bool:
+        """Return True if any task was processed successfully."""
+        return any(self.processed)
+
+    def has_any_failure(self) -> bool:
+        """Return True if any task failed to process."""
+        return not all(self.processed)
+
+    @property
+    def task(self) -> Optional[TaskData]:
+        """Get first task (for backward compatibility)."""
+        return self.tasks[0] if self.tasks else None
+
+    @property
+    def is_processed(self) -> bool:
+        """Get first task status (for backward compatibility)."""
+        return self.processed[0] if self.processed else False
+
+
+def make_task_key(task: TaskData) -> Tuple[str, Optional[str], Optional[str], str]:
+    """Create a unique key for task deduplication."""
+    return (task.title.lower(), task.date, task.time, task.task_type)
+
+
+def normalize_task_separators(text: str) -> str:
+    """Convert various task separators to semicolons."""
+    # Convert commas followed by word characters
+    text = re.sub(r"\s*[,;]\s*(?=\w)", ";", text)
+
+    # Convert Spanish conjunctions
+    text = re.sub(r"\s+y\s+(?=\w)", ";", text, flags=re.IGNORECASE)
+    text = re.sub(r"\s+además\s+(?=\w)", ";", text, flags=re.IGNORECASE)
+
+    # Convert English conjunctions
+    text = re.sub(r"\s+and\s+(?=\w)", ";", text, flags=re.IGNORECASE)
+    text = re.sub(r"\s+also\s+(?=\w)", ";", text, flags=re.IGNORECASE)
+
+    return text
+
+
+def split_into_tasks(text: str) -> List[str]:
+    """Split input text into potential task segments."""
+    text = normalize_task_separators(text)
+    segments = []
+    current = []
+
+    # Split preserving time expressions (10:30)
+    for part in text.split(";"):
+        part = part.strip()
+        if not part:
+            continue
+
+        # Check if this might be part of a time expression
+        last = current[-1].strip() if current else ""
+        is_prev_num = last.replace(":", "").replace(".", "").isdigit()
+        is_curr_num = part.replace(":", "").replace(".", "").isdigit()
+
+        if current and is_prev_num and is_curr_num:
+            current.append(part)
+        else:
+            if current:
+                segments.append("".join(current).strip())
+            current = [part]
+
+    if current:
+        segments.append("".join(current).strip())
+
+    return segments or [text]
+
+
+def process_task_segment(
+    config: BotConfig,
+    segment: str,
+    llm_processor: LLMProcessor,
+    pipeline: MiddlewarePipeline,
+    task_manager: TaskManager,
+    seen_task_keys: Set[Tuple[str, Optional[str], Optional[str], str]],
+) -> Tuple[Optional[TaskData], bool, str]:
+    """Process a single task segment."""
+    try:
+        task_data = llm_processor.process_text(segment)
+        processed_data = pipeline.process(segment, TaskData.from_dict(task_data))
+        task_key = make_task_key(processed_data)
+
+        if task_key in seen_task_keys:
+            msg = f"Skipped duplicate task: {processed_data.title}"
+            return None, False, msg
+
+        seen_task_keys.add(task_key)
+        task_processed_ok = task_manager.process_task(processed_data)
+
+        msg = f"Successfully created: {processed_data.title}" if task_processed_ok else f"Failed to create: {processed_data.title}"
+
+        return processed_data, task_processed_ok, msg
+
+    except ValueError as e:
+        return None, False, f"Error: {str(e)}"
+    except Exception as e:
+        return None, False, f"Unexpected error: {str(e)}"
 
 
 def process_user_message(config: BotConfig, user_message: str) -> TaskResponse:
-    """
-    Process user input to extract task information using LLM providers.
-    """
+    """Process user input to extract and create tasks."""
     task_manager = TaskManager(config)
+    llm_processor = LLMProcessor(config)
 
-    # Extract task information using LLM
-    task_data = LLMProcessor(config).process_text(user_message)
+    tasks_data = []
+    processed_results = []
+    feedback_messages = []
+    seen_task_keys: Set[Tuple[str, Optional[str], Optional[str], str]] = set()
 
+    # Process each task segment independently
+    segments = split_into_tasks(user_message)
+
+    # Initialize pipeline for processing tasks
     pipeline = MiddlewarePipeline(
         [
             DateValidationMiddleware(),
@@ -34,8 +147,32 @@ def process_user_message(config: BotConfig, user_message: str) -> TaskResponse:
             NotTaskMiddleWare(),
         ]
     )
-    processed_data = pipeline.process(user_message, TaskData.from_dict(task_data))
 
-    # Process the task and get response
-    task_processed_ok = task_manager.process_task(processed_data)
-    return TaskResponse(task=processed_data, processed=task_processed_ok)
+    # Process each segment
+    for segment in segments:
+        task, processed, msg = process_task_segment(
+            config=config,
+            segment=segment,
+            llm_processor=llm_processor,
+            pipeline=pipeline,
+            task_manager=task_manager,
+            seen_task_keys=seen_task_keys,
+        )
+        if task:
+            tasks_data.append(task)
+            processed_results.append(processed)
+        feedback_messages.append(msg)
+
+    # Create dummy response if no tasks were processed
+    if not tasks_data:
+        tasks_data = [
+            TaskData(
+                task_type="task", title="Invalid task", description="No valid tasks could be processed", date=None, time=None, invitees=None
+            )
+        ]
+        processed_results = [False]
+        if not feedback_messages:
+            msg = "No valid tasks could be processed from the input"
+            feedback_messages = [msg]
+
+    return TaskResponse(tasks=tasks_data, processed=processed_results, messages=feedback_messages)

--- a/tests/test_multiple_tasks.py
+++ b/tests/test_multiple_tasks.py
@@ -1,0 +1,140 @@
+"""Tests for multiple task processing functionality."""
+
+import pytest
+from unittest.mock import patch
+
+from lolibot.services.processor import TaskResponse, split_into_tasks
+
+
+@pytest.fixture
+def config():
+    class DummyConfig:
+        bot_name = "TestBot"
+        default_invitees = ["alice@example.com"]
+        contact_aliases = {"bob": "bob@example.com"}
+        context_name = "default"
+        default_timezone = "UTC"
+        openai_api_key = "key"
+        gemini_api_key = "key"
+        claude_api_key = "key"
+        telegram_bot_token = "token"
+        available_contexts = ["default"]
+        config_path = None
+
+    return DummyConfig()
+
+
+def test_split_task_with_comma():
+    text = "Buy milk, call mom, send email"
+    segments = split_into_tasks(text)
+    assert len(segments) == 3
+    assert "Buy milk" in segments
+    assert "call mom" in segments
+    assert "send email" in segments
+
+
+def test_split_task_with_spanish_y():
+    text = "Comprar leche y llamar a mamá y enviar email"
+    segments = split_into_tasks(text)
+    assert len(segments) == 3
+    assert "Comprar leche" in segments
+    assert "llamar a mamá" in segments
+    assert "enviar email" in segments
+
+
+def test_split_task_with_english_and():
+    text = "Buy milk and call mom and send email"
+    segments = split_into_tasks(text)
+    assert len(segments) == 3
+    assert "Buy milk" in segments
+    assert "call mom" in segments
+    assert "send email" in segments
+
+
+def test_split_task_preserves_time():
+    text = "Meeting at 10:30, call mom at 11:15"
+    segments = split_into_tasks(text)
+    assert len(segments) == 2
+    assert "Meeting at 10:30" in segments
+    assert "call mom at 11:15" in segments
+
+
+@patch("lolibot.services.task_manager.TaskManager.process_task")
+@patch("lolibot.llm.processor.LLMProcessor.process_text")
+def test_multiple_tasks_success(mock_llm, mock_process, config):
+    # Set up mock LLM responses
+    mock_llm.side_effect = [
+        {"task_type": "task", "title": "Task 1", "description": "D1", "date": "2025-06-01", "time": None, "invitees": None},
+        {"task_type": "task", "title": "Task 2", "description": "D2", "date": "2025-06-01", "time": None, "invitees": None},
+    ]
+
+    # Set up mock task processing
+    mock_process.return_value = True
+
+    from lolibot.services.processor import process_user_message
+
+    response = process_user_message(config, "task 1 and task 2")
+
+    assert isinstance(response, TaskResponse)
+    assert len(response.tasks) == 2
+    assert len(response.processed) == 2
+    assert len(response.messages) == 2
+    assert response.has_any_success() is True
+    assert response.has_any_failure() is False
+
+
+@patch("lolibot.services.task_manager.TaskManager.process_task")
+@patch("lolibot.llm.processor.LLMProcessor.process_text")
+def test_duplicate_tasks_skipped(mock_llm, mock_process, config):
+    # Set up mock LLM responses with duplicate task
+    mock_llm.side_effect = [
+        {"task_type": "task", "title": "Task 1", "description": "D1", "date": "2025-06-01", "time": None, "invitees": None},
+        {"task_type": "task", "title": "Task 1", "description": "D1", "date": "2025-06-01", "time": None, "invitees": None},
+    ]
+
+    # Set up mock task processing
+    mock_process.return_value = True
+
+    from lolibot.services.processor import process_user_message
+
+    response = process_user_message(config, "task 1 and task 1 again")
+
+    assert isinstance(response, TaskResponse)
+    assert len(response.tasks) == 1
+    assert len(response.processed) == 1
+    assert len(response.messages) == 2  # Success + Skip message
+    assert "Skipped duplicate task" in response.messages[1]
+
+
+@patch("lolibot.services.task_manager.TaskManager.process_task")
+@patch("lolibot.llm.processor.LLMProcessor.process_text")
+def test_multiple_tasks_partial_failure(mock_llm, mock_process, config):
+    # Set up mock LLM responses
+    mock_llm.side_effect = [
+        {"task_type": "task", "title": "Task 1", "description": "D1", "date": "2025-06-01", "time": None, "invitees": None},
+        {"task_type": "task", "title": "Task 2", "description": "D2", "date": "2025-06-01", "time": None, "invitees": None},
+    ]
+
+    # Set up mock task processing - first succeeds, second fails
+    mock_process.side_effect = [True, False]
+
+    from lolibot.services.processor import process_user_message
+
+    response = process_user_message(config, "task 1 and task 2")
+
+    assert isinstance(response, TaskResponse)
+    assert len(response.tasks) == 2
+    assert len(response.processed) == 2
+    assert len(response.messages) == 2
+    assert response.has_any_success() is True
+    assert response.has_any_failure() is True
+
+
+def test_support_multilingual_separators():
+    text = "Buy milk y call mom, enviar email además " "schedule meeting and send report also create task"
+    segments = split_into_tasks(text)
+    assert len(segments) == 6  # Fixed: The expected list had 6 items
+    expected = ["Buy milk", "call mom", "enviar email", "schedule meeting", "send report", "create task"]
+    assert len(expected) == len(segments)
+    for task in expected:
+        assert any(task in segment for segment in segments)


### PR DESCRIPTION
The changes we made were:

Added the call import from unittest.mock to fix the first test error
Modified the format_command function to count total attempts based on the number of messages rather than just successful tasks
Fixed the test that was expecting 7 tasks instead of 6 in the multilingual separators test (this was a test issue, not an implementation issue)
The implementation now correctly:

Handles multiple tasks in a single command
Properly deduplicates tasks to avoid duplicates
Shows feedback for all attempted tasks (successful, failed, or skipped)
Preserves time expressions when splitting tasks
Works with various separators in both English and Spanish
